### PR TITLE
Update Python run requirement to match host requirement (support 3.12)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - networkx >=3.0
     - types-protobuf >=4.24.0,<5.0.0
     - sqlalchemy >=1.4.49
-    - python >=3.8,<3.12
+    - python >=3.8.1,<4.0
     - SQLAlchemy >=1.4.49
     - greenlet !=0.4.17
     - beautifulsoup4 >=4.12.2,<5.0.0


### PR DESCRIPTION
Llama index 0.10.34 now supports Python 3.12. This was reflected in `requirements.host` but not `requirements.run`. This ought to resolve the following incompatible packages error:

```
error    libmamba Could not solve for environment specs
    The following packages are incompatible
    ├─ llama-index 0.10.34**  is installable and it requires
    │  └─ python >=3.8,<3.12  with the potential options
    │     ├─ python [3.10.0|3.10.1|...|3.9.9], which can be installed;
    │     └─ python 3.12.0rc3 would require
    │        └─ _python_rc, which does not exist (perhaps a missing channel);
    └─ pin-1 is not installable because it requires
       └─ python 3.12.* , which conflicts with any installable versions previously reported.
```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
