### PR TITLE
Update dependencies to match main repo

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - poetry
     - poetry-core
   run:
+    - python >={{ python_min }}
     - llama-index-cli >=0.4.0,<0.5.0
     - llama-index-indices-managed-llama-cloud >=0.4.0
     - llama-index-readers-llama-parse >=0.4.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
   run_constrained:
     - langchain >=0.0.303
     - asyncpg >=0.28.0,<0.29.0
-    - pgvector >=0.1.0,<0.2.0
+    - pgvector >=0.3.6,<1.0.0
     - psycopg-binary >=3.1.12,<4.0.0
     - optimum >=1.13.2,<2.0.0
     - onnxruntime >=1.11.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "llama-index" %}
 {% set version = "0.12.10" %}
+{% set python_min = "3.9" %}
 
 package:
   name: {{ name|lower }}
@@ -36,7 +37,7 @@ requirements:
     - nltk >3.8.1
   run_constrained:
     - langchain >=0.0.303
-    - asyncpg >=0.28.0,<0.29.0
+    - asyncpg >=0.29.0,<0.30.0
     - pgvector >=0.3.6,<1.0.0
     - psycopg-binary >=3.1.12,<4.0.0
     - optimum >=1.13.2,<2.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -33,30 +33,7 @@ requirements:
     - llama-index-program-openai >=0.3.0,<0.4.0
     - llama-index-question-gen-openai >=0.3.0,<0.4.0
     - llama-index-readers-file >=0.4.0,<0.5.0
-    - dirtyjson >=1.0.8,<2.0.0
-    - networkx >=3.0
-    - types-protobuf >=4.24.0,<5.0.0
-    - sqlalchemy >=1.4.49
-    - python >={{ python_min }}
-    - SQLAlchemy >=1.4.49
-    - greenlet !=0.4.17
-    - beautifulsoup4 >=4.12.2,<5.0.0
-    - dataclasses-json
-    - deprecated >=1.2.9.3
-    - fsspec >=2023.5.0
-    - httpx
-    - nest-asyncio >=1.5.8,<2.0.0
     - nltk >3.8.1
-    - numpy
-    - openai >=1.1.0
-    - pandas
-    - tenacity >=8.2.0,<9.0.0
-    - tiktoken >=0.3.3
-    - typing-extensions >=4.5.0
-    - typing_inspect >=0.8.0
-    - requests >=2.31.0
-    - aiostream >=0.5.2,<0.6.0
-    - aiohttp >=3.8.6,<4.0.0
   run_constrained:
     - langchain >=0.0.303
     - asyncpg >=0.28.0,<0.29.0
@@ -67,13 +44,13 @@ requirements:
     - datasets >=1.2.1
     - evaluate
     - protobuf >=3.20.1
-    - sentencepiece >=0.1.99,<0.2.0
+    - sentencepiece *
     - transformers >=4.34.0,<5.0.0
     - guidance >=0.0.64,<1.0.0
     - lm-format-enforcer >=0.4.3,<0.5.0
     - jsonpath-ng >=1.6.0,<2.0.0
     - rank-bm25 >=0.2.2,<0.3.0
-    - scikit-learn <1.3.0
+    - scikit-learn *
     - spacy >=3.7.1,<4.0.0
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Updating dependencies to match those on open source llama-index (https://github.com/run-llama/llama_index/blob/main/pyproject.toml#L50-L64). Many unnecessary dependencies which are already handled by child llama-index-* dependencies. Loosening constraints on sentencepiece, scikit-learn as these have '*' dependency wherever they're used in llama-index (https://github.com/search?q=repo%3Arun-llama%2Fllama_index%20scikit-learn&type=code, https://github.com/search?q=repo%3Arun-llama%2Fllama_index+sentencepiece&type=code).  Also updating pgvector to match only use in the repo (https://github.com/run-llama/llama_index/blob/main/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml#L34). And adds python_min.

Fixes https://github.com/conda-forge/llama-index-feedstock/issues/104, https://github.com/conda-forge/llama-index-feedstock/issues/146